### PR TITLE
prop Drilling을 막기 위해 최상위 검색 상태값 useState대신 useRef 사용

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,6 @@
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.1",
         "@types/node": "^16.11.35",
-        "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.4",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -24,6 +23,9 @@
         "react-scripts": "5.0.1",
         "typescript": "^4.6.4",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@types/react": "^18.0.9"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,6 @@
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.5.1",
     "@types/node": "^16.11.35",
-    "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
@@ -43,5 +42,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.9"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 
 import { Container } from "@mui/material";
@@ -17,11 +17,11 @@ import SignUp from "./Pages/SignUp";
 import Intro from "./Pages/Intro";
 
 function App() {
-    const [search, setSearch] = useState<string | null>("");
+    const searchRef = useRef('');
 
     return (
         <Router>
-            <Header search={search} setSearch={setSearch} />
+            <Header searchRef={searchRef} />
             <Container style={{ position: "fixed", top: "40px" }}>
                 <Routes>
                     <Route path="/*" element={<Error />} />

--- a/frontend/src/Component/Header.tsx
+++ b/frontend/src/Component/Header.tsx
@@ -1,30 +1,38 @@
 import { Grid, styled, Box, TextField } from "@mui/material";
-import { useState, useRef } from "react";
+import { useState, useEffect, type MutableRefObject } from "react";
 import "../Assets/Styles/Header.css";
 
 interface ISearchInterface {
-    search: string | null;
-    setSearch: React.Dispatch<React.SetStateAction<string | null>>;
+    searchRef: MutableRefObject<string>
 }
 
-function SearchField({ search, setSearch }: ISearchInterface) {
+function SearchField({ searchRef }: ISearchInterface) {
+    const [localSearch, setLocalSearch] = useState<string>('');
+
+
+    useEffect(() => {
+        searchRef.current = localSearch;
+    }, [localSearch]);
+
+
+
     return (
         <TextField
             style={{ width: "90%" }}
             size="small"
             variant="outlined"
-            // value={search}
+            value={localSearch}
             label="검색"
             autoFocus
             onChange={(e) => {
                 console.log(e.target.value);
-                setSearch(e.target.value);
+                setLocalSearch(e.target.value);
             }}
         />
     );
 }
 
-function Header({ search, setSearch }: ISearchInterface) {
+function Header({ searchRef }: ISearchInterface) {
     const HeaderGridItem = styled(Grid)({
         textAlign: "center",
     });
@@ -46,7 +54,7 @@ function Header({ search, setSearch }: ISearchInterface) {
                     </a>
                 </HeaderGridItem>
                 <HeaderGridItem item xs={6}>
-                    <SearchField search={search} setSearch={setSearch} />
+                    <SearchField searchRef={searchRef} />
                 </HeaderGridItem>
                 <HeaderGridItem item xs={3}>
                     item


### PR DESCRIPTION
## 문제 정의
상위 컴포넌트의 상태값을 바로 넘겨버리기 때문에 search, setSearch 값이 변할 때마다 재렌더링이 일어남.
이 현상은 지역 변수의 경우에도 똑같지만, SearchField 컴포넌트를 포함하고 있는 Header 컴포넌트 자체가 재렌더링되기 때문에 autofocus등 입력 기능이 잘 되지 않는 문제가 발생함.

## 해결 방법
useRef의 반환값인 ref 객체는 값이 변해도 재렌더링이 되지 않으므로 적절하다고 생각되었음. (object는 reference type이므로)
간단하게 useState 대신 useRef를 통해 현재값을 갱신시킴.
추후 값 사용이 필요할 경우 searchRef.current를 사용하면 될 듯함.